### PR TITLE
Collapsible Filters

### DIFF
--- a/src/components/PodcastList.tsx
+++ b/src/components/PodcastList.tsx
@@ -5,7 +5,7 @@ import { Podcast } from '../types';
 
 function PodcastList({ podcasts }: { podcasts: Podcast[] }) {
   return (
-    <ul>
+    <ul className="PodcastList">
       {podcasts.map((podcast: Podcast) => (
         <PodcastCard
           podcast={podcast}

--- a/src/components/ShowFilter.tsx
+++ b/src/components/ShowFilter.tsx
@@ -22,8 +22,8 @@ function ShowFilter({
 
   return (
     <div className="accordion">
-      <i></i>
       <input type="checkbox" id="podcast-filters" />
+      <i></i>
       <label className="accordion-label" htmlFor="podcast-filters">
         Podcasts
       </label>

--- a/src/components/ShowFilter.tsx
+++ b/src/components/ShowFilter.tsx
@@ -22,11 +22,13 @@ function ShowFilter({
 
   return (
     <div className="accordion">
-      <input type="checkbox" id="podcast-filters" />
-      <i></i>
-      <label className="accordion-label" htmlFor="podcast-filters">
-        Podcasts
-      </label>
+      <div className="accordion-label-container">
+        <input type="checkbox" id="podcast-filters" />
+        <label className="accordion-label" htmlFor="podcast-filters">
+          Podcasts
+        </label>
+        <i></i>
+      </div>
       <div className="accordion-content">
         <ul className="ShowFilter">
           {uniqueShows.map((show) => {

--- a/src/components/ShowFilter.tsx
+++ b/src/components/ShowFilter.tsx
@@ -21,21 +21,30 @@ function ShowFilter({
     });
 
   return (
-    <ul className="ShowFilter">
-      {uniqueShows.map((show) => {
-        const isSelected = includedShows.indexOf(show) > -1;
+    <div className="accordion">
+      <i></i>
+      <input type="checkbox" id="podcast-filters" />
+      <label className="accordion-label" htmlFor="podcast-filters">
+        Podcasts
+      </label>
+      <div className="accordion-content">
+        <ul className="ShowFilter">
+          {uniqueShows.map((show) => {
+            const isSelected = includedShows.indexOf(show) > -1;
 
-        return (
-          <li key={show}>
-            <Button
-              showTitle={show}
-              handleClick={handleShowClick}
-              isSelected={isSelected}
-            />
-          </li>
-        );
-      })}
-    </ul>
+            return (
+              <li key={show}>
+                <Button
+                  showTitle={show}
+                  handleClick={handleShowClick}
+                  isSelected={isSelected}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/ShowFilter.tsx
+++ b/src/components/ShowFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Button from './Button';
 
 import { Podcast } from '../types';

--- a/src/index.css
+++ b/src/index.css
@@ -89,7 +89,10 @@ h3 {
   flex-flow: wrap;
 }
 
-/* Checkbox */
+/* 
+Checkbox 
+taken from https: //dev.to/sababg/css-only-accordion-59db
+*/
 
 .accordion {
   overflow: hidden;
@@ -121,4 +124,79 @@ label {
   margin-inline-start: 0px;
   margin-inline-end: 0px;
   font-weight: bold;
+}
+
+/*
+icon styles taken from https: //codepen.io/alvarotrigo/pen/qBpBezx?editors=1100
+*/
+
+.transition,
+i:before,
+i:after {
+  transition: all 0.25s ease-in-out;
+}
+
+.flipIn {
+  animation: flipdown 0.5s ease both;
+}
+
+i {
+  position: absolute;
+  transform: translate(-6px, 0);
+  margin-top: 16px;
+  right: 0;
+}
+
+i:before,
+i:after {
+  content: "";
+  position: absolute;
+  background-color: #ff6873;
+  width: 3px;
+  height: 9px;
+}
+
+i:before {
+  transform: translate(-2px, 0) rotate(45deg);
+}
+
+i:after {
+  transform: translate(2px, 0) rotate(-45deg);
+}
+
+input[type=checkbox]:checked ~ i:before {
+  transform: translate(2px, 0) rotate(45deg);
+}
+
+input[type=checkbox]:checked ~ i:after {
+  transform: translate(-2px, 0) rotate(-45deg);
+}
+
+@keyframes flipdown {
+  0% {
+    opacity: 0;
+    transform-origin: top center;
+    transform: rotateX(-90deg);
+  }
+
+  5% {
+    opacity: 1;
+  }
+
+  80% {
+    transform: rotateX(8deg);
+  }
+
+  83% {
+    transform: rotateX(6deg);
+  }
+
+  92% {
+    transform: rotateX(-3deg);
+  }
+
+  100% {
+    transform-origin: top center;
+    transform: rotateX(0deg);
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -82,11 +82,14 @@ h3 {
 /* ShowFilter */
 
 .ShowFilter {
-  margin-bottom: 1.5rem;
   display: flex;
   flex-direction: row;
   gap: 7px 7px;
   flex-flow: wrap;
+}
+
+.PodcastList {
+  margin-top: 1.5rem;
 }
 
 /* 
@@ -113,7 +116,7 @@ input#podcast-filters {
   transition: all 0.35s;
 }
 
-input:checked~.accordion-content {
+input:checked ~ .accordion-content {
   max-height: 100vh;
 }
 
@@ -149,7 +152,7 @@ i {
 
 i:before,
 i:after {
-  content: "";
+  content: '';
   position: absolute;
   background-color: #ff6873;
   width: 3px;
@@ -164,11 +167,11 @@ i:after {
   transform: translate(2px, 0) rotate(-45deg);
 }
 
-input[type=checkbox]:checked ~ i:before {
+input[type='checkbox']:checked ~ i:before {
   transform: translate(2px, 0) rotate(45deg);
 }
 
-input[type=checkbox]:checked ~ i:after {
+input[type='checkbox']:checked ~ i:after {
   transform: translate(-2px, 0) rotate(-45deg);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -116,8 +116,15 @@ input#podcast-filters {
   transition: all 0.35s;
 }
 
-input:checked ~ .accordion-content {
+.accordion-label-container:has(input:checked) ~ .accordion-content {
   max-height: 100vh;
+}
+
+.accordion-label-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
 }
 
 label {
@@ -144,10 +151,10 @@ i:after {
 }
 
 i {
-  position: absolute;
-  transform: translate(-6px, 0);
-  margin-top: 16px;
-  right: 0;
+  display: inline-block;
+  height: 9px;
+  width: 3px;
+  margin-left: 0.75rem;
 }
 
 i:before,

--- a/src/index.css
+++ b/src/index.css
@@ -154,7 +154,7 @@ i:before,
 i:after {
   content: '';
   position: absolute;
-  background-color: #ff6873;
+  background-color: var(--blue);
   width: 3px;
   height: 9px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -88,3 +88,37 @@ h3 {
   gap: 7px 7px;
   flex-flow: wrap;
 }
+
+/* Checkbox */
+
+.accordion {
+  overflow: hidden;
+}
+
+input#podcast-filters {
+  position: absolute;
+  opacity: 0;
+  z-index: -1;
+}
+
+.accordion-label {
+  cursor: pointer;
+}
+
+.accordion-content {
+  max-height: 0;
+  transition: all 0.35s;
+}
+
+input:checked~.accordion-content {
+  max-height: 100vh;
+}
+
+label {
+  font-size: 1.5em;
+  margin-block-start: 0.83em;
+  margin-block-end: 0.83em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+}


### PR DESCRIPTION
This pull request allows the podcast filter tags to be collapsed and expanded, an accordion.

The collapsible behavior is driven by CSS and HTML, based on [this blog post](https://dev.to/sababg/css-only-accordion-59db).

The icon is taken from this [Codepen](https://codepen.io/alvarotrigo/pen/qBpBezx?editors=1100).